### PR TITLE
IACS-334 Enable k8s CustomResource

### DIFF
--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -18,6 +18,10 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 )
 
+var skipCheckPropsResourceNames = map[string]bool{
+	"kubernetes:apiextensions.k8s.io:CustomResource": true,
+}
+
 // Query the typing of a typed program.
 //
 // If the program failed to establish the type of a variable, then `*schema.InvalidType`
@@ -597,10 +601,12 @@ func (tc *typeCache) typeResource(r *Runner, node resourceNode) bool {
 		)
 	}
 
+	_, skipCheckProps := skipCheckPropsResourceNames[typ.String()]
+
 	// We type check properties if
 	// 1. They exist, or
 	// 2. The resource doesn't have a `Get` field (catching missing properties)
-	if resourceHasProperties || !resourceIsGet {
+	if (resourceHasProperties || !resourceIsGet) && !skipCheckProps {
 		tc.typePropertyEntries(ctx, k, typ.String(), fmtr, v.Properties.Entries, hint.Resource.InputProperties)
 	}
 

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -601,7 +601,7 @@ func (tc *typeCache) typeResource(r *Runner, node resourceNode) bool {
 		)
 	}
 
-	_, skipCheckProps := skipCheckPropsResourceNames[typ.String()]
+	skipCheckProps := skipCheckPropsResourceNames[typ.String()]
 
 	// We type check properties if
 	// 1. They exist, or

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -229,10 +229,10 @@ var docker3ResourceNames = map[string]struct{}{
 }
 
 var kubernetesResourceNames = map[string]string{
-	"kubernetes:apiextensions.k8s.io:CustomResource": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-	"kubernetes:kustomize:Directory":                 "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-	"kubernetes:yaml:ConfigFile":                     "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-	"kubernetes:yaml:ConfigGroup":                    "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	// "kubernetes:apiextensions.k8s.io:CustomResource": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	"kubernetes:kustomize:Directory": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	"kubernetes:yaml:ConfigFile":     "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	"kubernetes:yaml:ConfigGroup":    "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 }
 
 var helmResourceNames = map[string]struct{}{

--- a/pkg/pulumiyaml/run_token_blocklist_test.go
+++ b/pkg/pulumiyaml/run_token_blocklist_test.go
@@ -54,7 +54,6 @@ resources:
 	expectedErrors := []string{
 		"<stdin>:5:11: error resolving type of resource dockerImageFull: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
 		"<stdin>:9:11: error resolving type of resource dockerImageShort: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
-		"<stdin>:19:11: error resolving type of resource kubeCustomResource: The resource type [kubernetes:apiextensions.k8s.io:CustomResource] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 		"<stdin>:21:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 		"<stdin>:23:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 		"<stdin>:25:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",

--- a/pkg/pulumiyaml/run_token_blocklist_test.go
+++ b/pkg/pulumiyaml/run_token_blocklist_test.go
@@ -31,8 +31,6 @@ resources:
       version: 4.0.0
   dockerImageOkAmbient:
     type: docker:Image
-  kubeCustomResource:
-    type: kubernetes:apiextensions.k8s.io:CustomResource
   kubeKustomizeDir:
     type: kubernetes:kustomize:Directory
   kubeYamlConfigFile:
@@ -54,11 +52,11 @@ resources:
 	expectedErrors := []string{
 		"<stdin>:5:11: error resolving type of resource dockerImageFull: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
 		"<stdin>:9:11: error resolving type of resource dockerImageShort: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
-		"<stdin>:21:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:23:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:25:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:27:11: error resolving type of resource helmChartV2: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
-		"<stdin>:29:11: error resolving type of resource helmChartV3: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
+		"<stdin>:19:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:21:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:23:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:25:11: error resolving type of resource helmChartV2: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
+		"<stdin>:27:11: error resolving type of resource helmChartV3: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
 	}
 	assert.ElementsMatch(t, expectedErrors, diagStrings)
 	assert.Len(t, diagStrings, len(expectedErrors))


### PR DESCRIPTION
Ticket: [IACS-334](https://m-pipe.atlassian.net/browse/IACS-334)

- KubernetesのCustomResourceに対応
  - CustomResourceのPropertyCheckをスキップしている(PulumiYamlのValidation用のSchemaが動的なタイプに対応していない為)

ビルド関係は以下のリポジトリで実施してます。
https://github.com/qmonus/iacs-pulumi-tools/pull/1

テスト結果は以下に記載しております。
 https://www.notion.so/nttcom/PulumiYaml-CustomResource-c2b10f8490c24a2d914db5aa77da5a72

ビルドしたコンテナイメージ: 
https://console.cloud.google.com/artifacts/docker/solarray-pro-83383605/asia-northeast1/valuestream/pulumi-patched/sha256:052206eee666a1715b5a8f6885f9c7338382b068ec849887678cbc1f9b9cf422?project=solarray-pro-83383605

[IACS-334]: https://m-pipe.atlassian.net/browse/IACS-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ