### PR TITLE
CORE-406 Update Pulumi Yaml version on pulumi-patched image

### DIFF
--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 )
 
+// List of resource names for skipping property checks.
+// JIRA: https://m-pipe.atlassian.net/browse/IACS-334
 var skipCheckPropsResourceNames = map[string]bool{
 	"kubernetes:apiextensions.k8s.io:CustomResource": true,
 }
@@ -620,6 +622,8 @@ func (tc *typeCache) typeResource(r *Runner, node resourceNode) bool {
 		)
 	}
 
+	// Skip property checks for the CustomResource type, as it has a dynamic schema.
+	// JIRA: https://m-pipe.atlassian.net/browse/IACS-334
 	skipCheckProps := skipCheckPropsResourceNames[typ.String()]
 
 	// We type check properties if

--- a/pkg/pulumiyaml/analyser.go
+++ b/pkg/pulumiyaml/analyser.go
@@ -18,6 +18,10 @@ import (
 	"github.com/pulumi/pulumi-yaml/pkg/pulumiyaml/syntax"
 )
 
+var skipCheckPropsResourceNames = map[string]bool{
+	"kubernetes:apiextensions.k8s.io:CustomResource": true,
+}
+
 // Query the typing of a typed program.
 //
 // If the program failed to establish the type of a variable, then `*schema.InvalidType`
@@ -597,10 +601,12 @@ func (tc *typeCache) typeResource(r *Runner, node resourceNode) bool {
 		)
 	}
 
+	skipCheckProps := skipCheckPropsResourceNames[typ.String()]
+
 	// We type check properties if
 	// 1. They exist, or
 	// 2. The resource doesn't have a `Get` field (catching missing properties)
-	if resourceHasProperties || !resourceIsGet {
+	if (resourceHasProperties || !resourceIsGet) && !skipCheckProps {
 		tc.typePropertyEntries(ctx, k, typ.String(), fmtr, v.Properties.Entries, hint.Resource.InputProperties)
 	}
 

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -229,10 +229,10 @@ var docker3ResourceNames = map[string]struct{}{
 }
 
 var kubernetesResourceNames = map[string]string{
-	"kubernetes:apiextensions.k8s.io:CustomResource": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-	"kubernetes:kustomize:Directory":                 "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-	"kubernetes:yaml:ConfigFile":                     "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-	"kubernetes:yaml:ConfigGroup":                    "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	// "kubernetes:apiextensions.k8s.io:CustomResource": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	"kubernetes:kustomize:Directory": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	"kubernetes:yaml:ConfigFile":     "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+	"kubernetes:yaml:ConfigGroup":    "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 }
 
 var helmResourceNames = map[string]struct{}{

--- a/pkg/pulumiyaml/packages.go
+++ b/pkg/pulumiyaml/packages.go
@@ -273,6 +273,8 @@ var docker3ResourceNames = map[string]struct{}{
 }
 
 var kubernetesResourceNames = map[string]string{
+	// Prevent errors with custom resource types that are not supported in YAML by commenting them out.
+	// JIRA: https://m-pipe.atlassian.net/browse/IACS-334
 	// "kubernetes:apiextensions.k8s.io:CustomResource": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 	"kubernetes:kustomize:Directory": "https://github.com/pulumi/pulumi-kubernetes/issues/1971",
 	"kubernetes:yaml:ConfigFile":     "https://github.com/pulumi/pulumi-kubernetes/issues/1971",

--- a/pkg/pulumiyaml/run.go
+++ b/pkg/pulumiyaml/run.go
@@ -1500,8 +1500,8 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 			res.(pulumi.CustomResource),
 			opts...)
 	} else {
-
-		// patch to deploy CustomResource (https://m-pipe.atlassian.net/browse/IACS-334)
+		// If the resource is a CustomResource, overwrite the type to match the format used by the Pulumi Kubernetes provider.
+		// JIRA: https://m-pipe.atlassian.net/browse/IACS-334
 		if v.Type.Value == "kubernetes:apiextensions.k8s.io:CustomResource" {
 			typ, err = resolveCustomResourceType(props)
 			if err != nil {
@@ -1522,6 +1522,10 @@ func (e *programEvaluator) registerResource(kvp resourceNode) (lateboundResource
 	return state, true
 }
 
+// resolveCustomResourceType constructs the type for a Kubernetes CustomResource.
+// The type is formatted as "kubernetes:<apiVersion>:<kind>", which is used by the Pulumi Kubernetes provider.
+// See: https://github.com/pulumi/pulumi-kubernetes/blob/v3.25.0/sdk/nodejs/apiextensions/customResource.ts#L91
+// JIRA: https://m-pipe.atlassian.net/browse/IACS-334
 func resolveCustomResourceType(props map[string]interface{}) (ResourceTypeToken, error) {
 	apiVersion, ok := props["apiVersion"].(string)
 	if !ok {

--- a/pkg/pulumiyaml/run_token_blocklist_test.go
+++ b/pkg/pulumiyaml/run_token_blocklist_test.go
@@ -31,8 +31,6 @@ resources:
       version: 4.0.0
   dockerImageOkAmbient:
     type: docker:Image
-  kubeCustomResource:
-    type: kubernetes:apiextensions.k8s.io:CustomResource
   kubeKustomizeDir:
     type: kubernetes:kustomize:Directory
   kubeYamlConfigFile:
@@ -54,12 +52,11 @@ resources:
 	expectedErrors := []string{
 		"<stdin>:5:11: error resolving type of resource dockerImageFull: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
 		"<stdin>:9:11: error resolving type of resource dockerImageShort: Docker Image resources are not supported in YAML without major version >= 4, see: https://github.com/pulumi/pulumi-yaml/issues/421",
-		"<stdin>:19:11: error resolving type of resource kubeCustomResource: The resource type [kubernetes:apiextensions.k8s.io:CustomResource] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:21:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:23:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:25:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
-		"<stdin>:27:11: error resolving type of resource helmChartV2: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
-		"<stdin>:29:11: error resolving type of resource helmChartV3: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
+		"<stdin>:19:11: error resolving type of resource kubeKustomizeDir: The resource type [kubernetes:kustomize:Directory] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:21:11: error resolving type of resource kubeYamlConfigFile: The resource type [kubernetes:yaml:ConfigFile] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:23:11: error resolving type of resource kubeYamlConfigGroup: The resource type [kubernetes:yaml:ConfigGroup] is not supported in YAML at this time, see: https://github.com/pulumi/pulumi-kubernetes/issues/1971",
+		"<stdin>:25:11: error resolving type of resource helmChartV2: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
+		"<stdin>:27:11: error resolving type of resource helmChartV3: Helm Chart resources are not supported in YAML, consider using the Helm Release resource instead: https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/",
 	}
 	assert.ElementsMatch(t, expectedErrors, diagStrings)
 	assert.Len(t, diagStrings, len(expectedErrors))


### PR DESCRIPTION
#### 変更内容
- 新しいPulumi Yamlのバージョン(v1.13.0)にパッチを適用しました。
  - 以前のパッチのブランチ(v1.1.1-patched)をMergeして、Conflictを解消しました。

#### チケット
[CORE-406](https://m-pipe.atlassian.net/browse/CORE-406)

#### 関連PR

- https://github.com/qmonus/pulumi-yaml/pull/3
- https://github.com/qmonus/iacs-pulumi-tools/pull/11
- https://github.com/qmonus/official-cloud-native-adapters-internal/pull/321

#### 参考資料
[Notion | Pulumi YAMLのパッチイメージの運用について](https://www.notion.so/nttcom/167f7921d5598082a767c566c84ba94c#167f7921d55980a4a1fdc4cc474e5471)

[CORE-406]: https://m-pipe.atlassian.net/browse/CORE-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ